### PR TITLE
D&D 2.1.x causes matchToHit attackBonus failure

### DIFF
--- a/module/summons-actor.mjs
+++ b/module/summons-actor.mjs
@@ -161,7 +161,7 @@ export class SummonsActor {
       // Match item to hit to match summoner
       if ( config.matchToHit && item.hasAttack ) {
         const toHit = SummonsActor._determineToHit(item);
-        itemUpdates["system.attackBonus"] = toHitTarget - toHit;
+        itemUpdates["system.attackBonus"] = `${toHitTarget - toHit}`;
       }
 
       // Match item save DC to match summoner


### PR DESCRIPTION
Schema validation in D&D 2.1.x causes model validation error as attackBonus is a string, not an int. Simple change to attackBonus to be a string