### PR TITLE
[#44] Accounts for Tidy Beta finalized sheet class

### DIFF
--- a/summoner.css
+++ b/summoner.css
@@ -76,7 +76,7 @@
   margin-left: 4px;
 }
 
-.tidy5e-kgar.sheet.item .arbron-summons-area {
+.tidy5e-sheet.sheet.item .arbron-summons-area {
   margin-block-end: 4px;
 
   h4 {


### PR DESCRIPTION
Related: #44 

Tidy has just gone to Beta, and as such, it has taken over the Module ID, and I've removed all of the `kgar` tags, which were present for the Alpha testing period.

Now, the sheets are classed with `tidy5e-sheet`. My apologies for the change so soon after integration with Summoner. I anticipate this not to change any further. This was an unfortunate issue of timing, since the rewrite is headed to V1 soon.